### PR TITLE
Feat: remove ERP verbs from IC panel

### DIFF
--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -352,6 +352,7 @@
 			return text2num(key)
 	return 0
 
+/*
 /mob/living/carbon/human/verb/toggle_genitals()
 	set category = "IC"
 	set name = "Expose/Hide genitals"
@@ -410,3 +411,4 @@
 			picked_organ.update_sprite_suffix()
 			update_body()
 	return
+*/

--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -151,6 +151,7 @@
 		apply_status_effect(/datum/status_effect/aroused)
 		apply_status_effect(/datum/status_effect/body_fluid_regen)
 
+/*
 ///////////-----Verbs------///////////
 /mob/living/carbon/human/verb/arousal_panel()
 	set name = "Climax"
@@ -165,6 +166,7 @@
 				climax(TRUE)
 	else
 		to_chat(src, span_warning("You can't cum right now!"))
+*/
 
 ////////////
 ///FLUIDS///


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Удаляет вербы climax, "hide/show genitals" и "toggle arousa" путем их комментирования.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Удаление ЕРП вербов, которые и так не активны

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Удаление ERP вербов с IC панели
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
