### PR TITLE
feat: ERP strippable inventory depends on config

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -21,6 +21,8 @@
 
 	RegisterSignal(target, COMSIG_MOUSEDROP_ONTO, .proc/mouse_drop_onto)
 
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		items -= GLOB.strippable_human_erp_items
 	src.items = items
 	src.should_strip_proc_path = should_strip_proc_path
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
ERP strippable inventory now depends on DISABLE_ERP_PREFERENCE config

This commit can be reverted: https://github.com/ss220-space/Skyrat-tg/commit/95207303e2f08a0f9b547ad47220db69350d9912

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Better NO-ERP experiences for builds who doesn't want that

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: ERP strippable inventory now depends on DISABLE_ERP_PREFERENCE config

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
