### PR TITLE
feat: Disables taur mutant part from config

### DIFF
--- a/modular_ss220/modules/mutant_part_disable/code/disable_taur.dm
+++ b/modular_ss220/modules/mutant_part_disable/code/disable_taur.dm
@@ -1,0 +1,13 @@
+//Disables taur
+/datum/config_entry/flag/disable_taur
+	default = FALSE
+
+/datum/preference/toggle/taur/is_accessible(datum/preferences/preferences)
+	if(CONFIG_GET(flag/disable_taur))
+		return FALSE
+	. = ..()
+
+/datum/preference/choiced/taur/is_accessible(datum/preferences/preferences)
+	if(CONFIG_GET(flag/disable_taur))
+		return FALSE
+	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds an ability to disable taur body parts via config. Need to add to config\skyrat\skyrat_config.txt

DISABLE_TAUR

This commit can be reverted: https://github.com/ss220-space/Skyrat-tg/commit/a4f9c8d4f97d6f32b5a261eccc2e9374199c88f1

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Less cringy (for some people) creatures

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Expands content of an existing feature
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
