### PR TITLE
Feat: add new 94 TTS voices from Witcher (27), Evil Islands (27), L4D (4), SpongeBob (4), Tiny Bunny (10), Dota 2 (13), STALKER (7), Warcraft 3 (1), Portal 2 (1)

### DIFF
--- a/modular_ss220/modules/tts/code/_tts_defines.dm
+++ b/modular_ss220/modules/tts/code/_tts_defines.dm
@@ -48,6 +48,10 @@
 #define TTS_CATEGORY_HEARTHSTONE "Hearthstone"
 #define TTS_CATEGORY_VALORANT "Valorant"
 #define TTS_CATEGORY_EVILISLANDS "Evil Islands"
+#define TTS_CATEGORY_WITCHER "Witcher"
+#define TTS_CATEGORY_LEFT4DEAD "Left 4 Dead"
+#define TTS_CATEGORY_SPONGEBOB "SpongeBob"
+#define TTS_CATEGORY_TINYBUNNY "Tiny Bunny"
 
 #define TTS_GENDER_ANY "Любой"
 #define TTS_GENDER_MALE "Мужской"

--- a/modular_ss220/modules/tts/code/seeds/silero.dm
+++ b/modular_ss220/modules/tts/code/seeds/silero.dm
@@ -3579,3 +3579,661 @@
 	category = TTS_CATEGORY_HEARTHSTONE
 	gender = TTS_GENDER_ANY
 	donator_level = 0
+
+/datum/tts_seed/silero/byasha
+	name = "Byasha"
+	value = "byasha"
+	category = TTS_CATEGORY_TINYBUNNY
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/cerys
+	name = "Cerys"
+	value = "cerys"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/philippa
+	name = "Philippa"
+	value = "philippa"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/oldnekro
+	name = "Oldnekro"
+	value = "oldnekro"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/lambert
+	name = "Lambert"
+	value = "lambert"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/shani
+	name = "Shani"
+	value = "shani"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/anton
+	name = "Anton"
+	value = "anton"
+	category = TTS_CATEGORY_TINYBUNNY
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/dolg1
+	name = "Dolg1"
+	value = "dolg1"
+	category = TTS_CATEGORY_STALKER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/guru
+	name = "Guru"
+	value = "guru"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/lugos
+	name = "Lugos"
+	value = "lugos"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/karina
+	name = "Karina"
+	value = "karina"
+	category = TTS_CATEGORY_TINYBUNNY
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/ewald
+	name = "Ewald"
+	value = "ewald"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/mirror
+	name = "Mirror"
+	value = "mirror"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/noble
+	name = "Noble"
+	value = "noble"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/huber
+	name = "Huber"
+	value = "huber"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/wywern
+	name = "Wywern"
+	value = "wywern"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/avallach
+	name = "Avallach"
+	value = "avallach"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/semen
+	name = "Semen"
+	value = "semen"
+	category = TTS_CATEGORY_TINYBUNNY
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/all_elder
+	name = "All_elder"
+	value = "all_elder"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/nsheriff
+	name = "Nsheriff"
+	value = "nsheriff"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/orcc
+	name = "Orcc"
+	value = "orcc"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/clerk
+	name = "Clerk"
+	value = "clerk"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/witch
+	name = "Witch"
+	value = "witch"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/deva
+	name = "Deva"
+	value = "deva"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/coach
+	name = "Coach"
+	value = "coach"
+	category = TTS_CATEGORY_LEFT4DEAD
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/dictor
+	name = "Dictor"
+	value = "dictor"
+	category = TTS_CATEGORY_PORTAL2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/monolith2
+	name = "Monolith2"
+	value = "monolith2"
+	category = TTS_CATEGORY_STALKER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/invoker
+	name = "Invoker"
+	value = "invoker"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/goblin
+	name = "Goblin"
+	value = "goblin"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/annah
+	name = "Annah"
+	value = "annah"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/patrick
+	name = "Patrick"
+	value = "patrick"
+	category = TTS_CATEGORY_SPONGEBOB
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/spongebob
+	name = "Spongebob"
+	value = "spongebob"
+	category = TTS_CATEGORY_SPONGEBOB
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/kapitan
+	name = "Kapitan"
+	value = "kapitan"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/karh
+	name = "Karh"
+	value = "karh"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/lydia_tb
+	name = "Lydia_tb"
+	value = "lydia_tb"
+	category = TTS_CATEGORY_TINYBUNNY
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/silencer
+	name = "Silencer"
+	value = "silencer"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/sheriff
+	name = "Sheriff"
+	value = "sheriff"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/lycan
+	name = "Lycan"
+	value = "lycan"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/cirilla
+	name = "Cirilla"
+	value = "cirilla"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/legends
+	name = "Legends"
+	value = "legends"
+	category = TTS_CATEGORY_STALKER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/monolith1
+	name = "Monolith1"
+	value = "monolith1"
+	category = TTS_CATEGORY_STALKER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/trapper
+	name = "Trapper"
+	value = "trapper"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/mirana
+	name = "Mirana"
+	value = "mirana"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/glav
+	name = "Glav"
+	value = "glav"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/syanna
+	name = "Syanna"
+	value = "syanna"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/regis
+	name = "Regis"
+	value = "regis"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/dazzle
+	name = "Dazzle"
+	value = "dazzle"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/mthief
+	name = "Mthief"
+	value = "mthief"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/guillaume
+	name = "Guillaume"
+	value = "guillaume"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/vivienne
+	name = "Vivienne"
+	value = "vivienne"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/plankton
+	name = "Plankton"
+	value = "plankton"
+	category = TTS_CATEGORY_SPONGEBOB
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/rochelle
+	name = "Rochelle"
+	value = "rochelle"
+	category = TTS_CATEGORY_LEFT4DEAD
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/vor
+	name = "Vor"
+	value = "vor"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/grandmother
+	name = "Grandmother"
+	value = "grandmother"
+	category = TTS_CATEGORY_TINYBUNNY
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/dolg2
+	name = "Dolg2"
+	value = "dolg2"
+	category = TTS_CATEGORY_STALKER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/junboy
+	name = "Junboy"
+	value = "junboy"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/shopper
+	name = "Shopper"
+	value = "shopper"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/papillon
+	name = "Papillon"
+	value = "papillon"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/cm
+	name = "Cm"
+	value = "cm"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/vesemir
+	name = "Vesemir"
+	value = "vesemir"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/kate
+	name = "Kate"
+	value = "kate"
+	category = TTS_CATEGORY_TINYBUNNY
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/polina
+	name = "Polina"
+	value = "polina"
+	category = TTS_CATEGORY_TINYBUNNY
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/crach
+	name = "Crach"
+	value = "crach"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/gryphon
+	name = "Gryphon"
+	value = "gryphon"
+	category = TTS_CATEGORY_WARCRAFT3
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/zeus
+	name = "Zeus"
+	value = "zeus"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/iz
+	name = "Iz"
+	value = "iz"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/geralt
+	name = "Geralt"
+	value = "geralt"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/stories
+	name = "Stories"
+	value = "stories"
+	category = TTS_CATEGORY_STALKER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/nekro
+	name = "Nekro"
+	value = "nekro"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/hwleader
+	name = "Hwleader"
+	value = "hwleader"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/yennefer
+	name = "Yennefer"
+	value = "yennefer"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/hero
+	name = "Hero"
+	value = "hero"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/baratrum
+	name = "Baratrum"
+	value = "baratrum"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/ellis
+	name = "Ellis"
+	value = "ellis"
+	category = TTS_CATEGORY_LEFT4DEAD
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/udalryk
+	name = "Udalryk"
+	value = "udalryk"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/dad
+	name = "Dad"
+	value = "dad"
+	category = TTS_CATEGORY_TINYBUNNY
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/smith
+	name = "Smith"
+	value = "smith"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/romka
+	name = "Romka"
+	value = "romka"
+	category = TTS_CATEGORY_TINYBUNNY
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/abaddon
+	name = "Abaddon"
+	value = "abaddon"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/eskel
+	name = "Eskel"
+	value = "eskel"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/freedom
+	name = "Freedom"
+	value = "freedom"
+	category = TTS_CATEGORY_STALKER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/magess
+	name = "Magess"
+	value = "magess"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_ANY
+	donator_level = 0
+
+/datum/tts_seed/silero/nalo
+	name = "Nalo"
+	value = "nalo"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/dandelion
+	name = "Dandelion"
+	value = "dandelion"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/palmerin
+	name = "Palmerin"
+	value = "palmerin"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/olgierd
+	name = "Olgierd"
+	value = "olgierd"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/d_sven
+	name = "D_sven"
+	value = "d_sven"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/triss
+	name = "Triss"
+	value = "triss"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_FEMALE
+	donator_level = 0
+
+/datum/tts_seed/silero/monkey
+	name = "Monkey"
+	value = "monkey"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/squidward
+	name = "Squidward"
+	value = "squidward"
+	category = TTS_CATEGORY_SPONGEBOB
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/ember
+	name = "Ember"
+	value = "ember"
+	category = TTS_CATEGORY_DOTA2
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/ycf
+	name = "Ycf"
+	value = "ycf"
+	category = TTS_CATEGORY_EVILISLANDS
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/nick
+	name = "Nick"
+	value = "nick"
+	category = TTS_CATEGORY_LEFT4DEAD
+	gender = TTS_GENDER_MALE
+	donator_level = 0
+
+/datum/tts_seed/silero/hjalmar
+	name = "Hjalmar"
+	value = "hjalmar"
+	category = TTS_CATEGORY_WITCHER
+	gender = TTS_GENDER_MALE
+	donator_level = 0


### PR DESCRIPTION
## About The Pull Request
Добавлены новые TTS голоса для Silero:
- **Witcher** (27): `cerys`, `philippa`, `lambert`, `shani`, `lugos`, `ewald`, `mirror`, `noble`, `avallach`, `annah`, `cirilla`, `syanna`, `regis`, `guillaume`, `vivienne`, `papillon`, `vesemir`, `crach`, `geralt`, `yennefer`, `udalryk`, `eskel`, `dandelion`, `palmerin`, `olgierd`, `triss`, `hjalmar`;
- **Evil Islands** (27): `oldnekro`, `guru`, `huber`, `all_elder`, `nsheriff`, `orcc`, `clerk`, `witch`, `deva`, `goblin`, `kapitan`, `karh`, `sheriff`, `trapper`, `glav`, `mthief`, `vor`, `junboy`, `shopper`, `iz`, `nekro`, `hwleader`, `hero`, `smith`, `magess`, `nalo`, `ycf`;
- **L4D** (4): `coach`, `rochelle`, `ellis`, `nick`;
- **SpongeBob** (4): `patrick`, `spongebob`, `plankton`, `squidward`;
- **Tiny Bunny** (10): `byasha`, `anton`, `karina`, `semen`, `lydia_tb`, `grandmother`, `kate`, `polina`, `dad`, `romka`, 
- **Dota 2** (13): `wywern`, `invoker`, `silencer`, `lycan`, `mirana`, `dazzle`, `cm`, `zeus`, `baratrum`, `abaddon`, `d_sven`, `monkey`, `ember`;
- **STALKER** (7): `dolg1`, `monolith2`, `legends`, `monolith1`, `dolg2`, `stories`, `freedom`;
- **Warcraft 3** (1): `gryphon`;
- **Portal 2** (1): `dictor`;

## Changelog

:cl: azizonkg
add: Added new 94 TTS voices from Witcher (27), Evil Islands (27), L4D (4), SpongeBob (4), Tiny Bunny (10), Dota 2 (13), STALKER (7), Warcraft 3 (1), Portal 2 (1)
/:cl: