### PR TITLE
syndicate_teleporter_return

### DIFF
--- a/modular_ss220/modules/syndicate_teleporter_return/syndicate_teleporter.dm
+++ b/modular_ss220/modules/syndicate_teleporter_return/syndicate_teleporter.dm
@@ -1,0 +1,8 @@
+/datum/uplink_item/device_tools/syndicate_teleporter
+	name = "Experimental Syndicate Teleporter"
+	desc = "A handheld device that teleports the user 4-8 meters forward. \
+			Beware, teleporting into a wall will trigger a parallel emergency teleport; \
+			however if that fails, you may need to be stitched back together. \
+			Comes with 4 charges, recharges randomly. Warranty null and void if exposed to an electromagnetic pulse."
+	item = /obj/item/storage/box/syndie_kit/syndicate_teleporter
+	cost = 8

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8840,6 +8840,7 @@
 #include "modular_ss220\modules\return_prs\gunsgalore\code\guns\scar.dm"
 #include "modular_ss220\modules\return_prs\gunsgalore\code\guns\stg.dm"
 #include "modular_ss220\modules\shutdown\shutdown_config.dm"
+#include "modular_ss220\modules\syndicate_teleporter_return\syndicate_teleporter.dm"
 #include "modular_ss220\modules\translations\code\customer_ru.dm"
 #include "modular_ss220\modules\tts\code\_tts_defines.dm"
 #include "modular_ss220\modules\tts\code\tts_configuration.dm"


### PR DESCRIPTION
## About The Pull Request
Всё понятно из названия, но для тех кто не понял возвращает синдителепортер
## How This Contributes To The Nova Sector Roleplay Experience
Жизнь ангагонистов станет немного проще, да и после нерфов ТГ (оригинальный пулреквест для тех кому надо https://github.com/tgstation/tgstation/pull/86807), предмет стал значительно слабее, но всё ещё полезен. 
https://discord.com/channels/617003227182792704/1308424907016638484/1309959022375473187 (предложка прошла)
## Proof of Testing
![image](https://github.com/user-attachments/assets/1782c8e3-305e-45b3-a58c-2722a03c3897)
![image](https://github.com/user-attachments/assets/65f2f321-e970-40e1-a990-b926ab8e315e)
## Changelog
:cl:
balance: syndicate teleporter return
/:cl:
